### PR TITLE
Fix blocking call of Container API

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -13,6 +13,8 @@ pub struct Container {
     pub port_expose: usize,
     pub port_internal: usize,
     pub blocking: bool,
+
+    /// command [arg...]
     pub ops: Vec<String>,
 }
 
@@ -79,10 +81,7 @@ impl Container {
 
         cmd.extend(vec![img.as_str()]);
 
-        if !self.ops.is_empty() {
-            let ops_str: Vec<&str> = self.ops.iter().map(|s| &**s).collect();
-            cmd.extend(ops_str);
-        }
+        cmd.extend(self.ops.iter().map(|s| s.as_str()));
 
         String::from(command::docker_exec(cmd).await.unwrap().trim())
     }

--- a/src/container.rs
+++ b/src/container.rs
@@ -10,7 +10,6 @@ pub struct Container {
     pub tag: String,
     pub volumes: Vec<String>,
     pub env: HashMap<String, String>,
-    pub cmd: String,
     pub port_expose: usize,
     pub port_internal: usize,
     pub blocking: bool,
@@ -54,7 +53,7 @@ impl Container {
         let env: Vec<&str> = e.iter().map(|s| s.as_str()).collect();
 
         if self.blocking {
-            cmd.extend(vec!["-a", "-rm"]);
+            cmd.extend(vec!["--rm"]);
         } else {
             cmd.extend(vec!["-d"]);
         }
@@ -133,5 +132,21 @@ mod tests {
         .await;
 
         stop_container(&ctn_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_run_blocking() {
+        let text = "test_text_print";
+
+        let output = Container {
+            repo: String::from("alpine"),
+            ops: vec![String::from("echo"), String::from(text)],
+            blocking: true,
+            ..Default::default()
+        }
+        .start()
+        .await;
+
+        assert_eq!(text, output)
     }
 }


### PR DESCRIPTION
The changes to lifetimes are a drive-by to avoid making all the string<>str conversions