### PR TITLE
Update async-process and Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-process = "1.6.0"
+async-process = "2.3.0"
 serde_json = "1.0.91"
 serde = { version = "1.0.150", features = ["derive"] }
 thiserror = "1.0.38"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
 
-channel = "1.66.1"
+channel = "1.82.0"


### PR DESCRIPTION
async-process 1.6.0 depends on instant, which is unmaintained: https://rustsec.org/advisories/RUSTSEC-2024-0384.html